### PR TITLE
[Example - 1] Overrides v2 - Add more icons option to the Alert component

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "CustomIconsAlert",
+    "schema": {
+      "title": "Alert with more Icon options",
+      "description": "Add an alert that has more Icon options",
+      "type": "object",
+      "required": ["icon", "content", "dismissible"],
+      "properties": {
+        "icon": {
+          "type": "string",
+          "title": "Icon",
+          "enumNames": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ],
+          "enum": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ]
+        },
+        "content": {
+          "type": "string",
+          "title": "Content"
+        },
+        "link": {
+          "title": "Link",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Link Text"
+            },
+            "to": {
+              "type": "string",
+              "title": "Action link"
+            }
+          }
+        },
+        "dismissible": {
+          "type": "boolean",
+          "default": false,
+          "title": "Is dismissible?"
+        }
+      }
+    }
+  }
+]

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+
+export default { CustomIconsAlert };

--- a/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
+++ b/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
@@ -1,0 +1,15 @@
+import { getOverriddenSection, AlertSection } from "@faststore/core";
+
+import styles from "./custom-icons-alert.module.scss";
+
+/**
+ * This is an Alert Section override with custom icon options in the Headless CMS.
+ *
+ * We'll change the schema to include more options for native Icons supported by @faststore/ui.  (Changes added to sections.json)
+ */
+const CustomIconsAlert = getOverriddenSection({
+  Section: AlertSection, // The native section to be overridden (Alert)
+  className: styles.customIconsAlert,
+});
+
+export default CustomIconsAlert;

--- a/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
+++ b/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
@@ -1,0 +1,12 @@
+.customIconsAlert {
+  [data-fs-alert] {
+    justify-content: center;
+    color: var(--fs-color-neutral-0);
+    background-color: var(--fs-color-neutral-7);
+  }
+
+  [data-fs-icon],
+  [data-fs-link] {
+    color: var(--fs-color-neutral-0);
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds use cases scenarios using [Section Override API v2](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/overrides-overview).

Section override allow you to replace native components within sections with custom ones. This maintains the core functionalities of native components while allowing you to adjust their appearance and behavior to suit your store's needs.

All component customizations happen within sections. You can create multiple overrides for native sections, resulting in a new React component representing the overridden section.

## Example

### [Use Case 1: Add more icons option to the Alert component](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/use-cases/add-icons-to-the-alert-component)

Common use for [getOverriddenSection](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/specification) in FastStore, focusing on customizing the Headless CMS schema for a section to provide more options.

- We'll create a new component `CustomIconsAlert` 
- Adds custom styles for it.

(Follow the doc guide)
- After sync in the CMS, you'll be able to see the new section available
<img width="1347" alt="image" src="https://github.com/vtex-sites/fun-playground.store/assets/3356699/764b0552-f805-4ea4-9b99-87831b997b0f">

- The `CustomIconsAlert` applied locally
<img width="1440" alt="image" src="https://github.com/vtex-sites/playground.store/assets/3356699/62b7d9d4-34c9-41c3-bd78-1e1e8d92c2ac">

 
