### PR TITLE
[Example - 2] Overrides v2 - Add an image at Alert component

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -54,5 +54,40 @@
         }
       }
     }
+  },
+  {
+    "name": "AlertWithImage",
+    "schema": {
+      "title": "Alert with image",
+      "description": "Add an Alert that has an Image as an icon",
+      "type": "object",
+      "required": ["src", "alt", "content", "dismissible"],
+      "properties": {
+        "src": {
+          "type": "string",
+          "title": "Image source",
+          "description": "Source of the Alert icon image"
+        },
+        "alt": {
+          "type": "string",
+          "title": "Image alt text",
+          "description": "Alt text for the Alert icon image"
+        },
+        "content": { "type": "string", "title": "Content" },
+        "link": {
+          "title": "Link",
+          "type": "object",
+          "properties": {
+            "text": { "type": "string", "title": "Link Text" },
+            "to": { "type": "string", "title": "Action link" }
+          }
+        },
+        "dismissible": {
+          "type": "boolean",
+          "default": false,
+          "title": "Is dismissible?"
+        }
+      }
+    }
   }
 ]

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,8 @@
 import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+import AlertWithImage from "./sections/AlertWithImage/AlertWithImage";
 
-export default { CustomIconsAlert };
+const sections = {
+  CustomIconsAlert,
+  AlertWithImage,
+};
+export default sections;

--- a/src/components/sections/AlertWithImage/AlertWithImage.tsx
+++ b/src/components/sections/AlertWithImage/AlertWithImage.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { AlertSection, getOverriddenSection } from "@faststore/core";
+
+// Image component to display the image (recommended to use this component instead of the native img tag - See Reference)
+import { Image_unstable as Image } from "@faststore/core/experimental";
+
+import styles from "./alert-with-image.module.scss";
+
+interface AlertWithImageProps
+  extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+  src: string;
+  alt: string;
+}
+
+/**
+ * This is an Alert Section override that contains an Image.
+ *
+ * We'll change the CMS schema to add the src option and remove the icon option. (Changes added to sections.json)
+ * Overrides the Icon option and passes down the other props
+ *
+ * It's memoized to avoid being re-created every time the AlertWithImage component is re-rendered
+ */
+
+export default function AlertWithImage(props: AlertWithImageProps) {
+  const { src, alt, ...otherProps } = props;
+
+  const OverriddenAlert = useMemo(
+    () =>
+      getOverriddenSection({
+        Section: AlertSection,
+        className: styles.alertWithImage,
+        components: {
+          Icon: {
+            Component: () => (
+              <Image src={props.src} alt={props.alt} width={24} height={24} />
+            ),
+          },
+        },
+      }),
+    []
+  );
+
+  return <OverriddenAlert {...otherProps} icon="" />;
+}

--- a/src/components/sections/AlertWithImage/alert-with-image.module.scss
+++ b/src/components/sections/AlertWithImage/alert-with-image.module.scss
@@ -1,0 +1,7 @@
+.alertWithImage {
+  [data-fs-image] {
+    width: 24px;
+    height: 24px;
+    margin-right: var(--fs-spacing-1);
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds use cases scenarios using [Section Override API v2](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/overrides-overview).

Section override allow you to replace native components within sections with custom ones. This maintains the core functionalities of native components while allowing you to adjust their appearance and behavior to suit your store's needs.

All component customizations happen within sections. You can create multiple overrides for native sections, resulting in a new React component representing the overridden section.

## Examples
 
### [Use Case 2: Add an image to your Alert component](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/use-cases/add-an-image-to-your-alert-component)

Display a custom image alongside the text in your alert messages.
The native Alert section provides an icon prop for customization, but you want more control and flexibility over the displayed content.

- We'll create a new component `AlertWithImage` 
- Uses FS `Image` experimental component to better perfomance

(Follow the doc guide)
- After sync in the CMS, you'll be able to see the new section available

<img width="916" alt="image" src="https://github.com/vtex-sites/playground.store/assets/3356699/d5e19218-70ed-46db-8cfd-b339c91371d7">

- The `AlertWithImage` applied locally
<img width="1440" alt="image" src="https://github.com/vtex-sites/playground.store/assets/3356699/ccbdad93-58f4-45e5-a931-f15a1cc50720">
