### PR TITLE
[Example] FS API extension using fragment - Adds available installments info

### DIFF
--- a/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
+++ b/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
@@ -2,6 +2,8 @@ import { usePDP } from "@faststore/core";
 import { Button as UIButton, ButtonProps } from "@faststore/ui";
 import { priceFormatter } from "../../utils/priceFormatter";
 
+import styles from "./buy-button-with-details.module.scss";
+
 export function BuyButtonWithDetails(props: ButtonProps) {
   // FastStore exposes the data that comes from FastStore API along with FastStore API Extensions inside a provider. Use the usePDP hook to access data from a Product Detail Page (PDP). Refer to: https://developers.vtex.com/docs/guides/faststore/api-extensions-consuming-api-extensions
   const context = usePDP();
@@ -13,7 +15,7 @@ export function BuyButtonWithDetails(props: ButtonProps) {
   const interestFree = installment.installmentInterest === 0 ?? false;
 
   return (
-    <section>
+    <section className={styles.buyButtonWithDetails}>
       {interestFree && (
         <span>
           {`${installment.installmentNumber} interest-free installment(s)`}

--- a/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
+++ b/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
@@ -1,0 +1,20 @@
+import { usePDP } from "@faststore/core";
+import { Button as UIButton, ButtonProps } from "@faststore/ui";
+
+export function BuyButtonWithDetails(props: ButtonProps) {
+  // FastStore exposes the data that comes from FastStore API along with FastStore API Extensions inside a provider. Use the usePDP hook to access data from a Product Detail Page (PDP). Refer to: https://developers.vtex.com/docs/guides/faststore/api-extensions-consuming-api-extensions
+  const context = usePDP();
+
+  console.log("🚀 ~ PDP context:", context);
+
+  // We will show one of the installments option available if the product has interest free
+  return (
+    <section>
+      <UIButton {...props} variant="primary">
+        New Buy Button
+      </UIButton>
+    </section>
+  );
+}
+
+export default BuyButtonWithDetails;

--- a/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
+++ b/src/components/BuyButtonWithDetails/BuyButtonWithDetails.tsx
@@ -1,5 +1,6 @@
 import { usePDP } from "@faststore/core";
 import { Button as UIButton, ButtonProps } from "@faststore/ui";
+import { priceFormatter } from "../../utils/priceFormatter";
 
 export function BuyButtonWithDetails(props: ButtonProps) {
   // FastStore exposes the data that comes from FastStore API along with FastStore API Extensions inside a provider. Use the usePDP hook to access data from a Product Detail Page (PDP). Refer to: https://developers.vtex.com/docs/guides/faststore/api-extensions-consuming-api-extensions
@@ -7,11 +8,24 @@ export function BuyButtonWithDetails(props: ButtonProps) {
 
   console.log("🚀 ~ PDP context:", context);
 
-  // We will show one of the installments option available if the product has interest free
+  // We will show one of the installments option available if the product has interest free (You should go further and show all available installments options)
+  const installment = context?.data?.product?.availableInstallments[0];
+  const interestFree = installment.installmentInterest === 0 ?? false;
+
   return (
     <section>
+      {interestFree && (
+        <span>
+          {`${installment.installmentNumber} interest-free installment(s)`}
+          <br />
+          {`of ${priceFormatter(installment.installmentValue)} with ${
+            installment.installmentPaymentSystemName
+          }`}
+        </span>
+      )}
+
       <UIButton {...props} variant="primary">
-        New Buy Button
+        Buy Button
       </UIButton>
     </section>
   );

--- a/src/components/BuyButtonWithDetails/buy-button-with-details.module.scss
+++ b/src/components/BuyButtonWithDetails/buy-button-with-details.module.scss
@@ -1,0 +1,16 @@
+.buyButtonWithDetails {
+  > span {
+    display: flex;
+    justify-content: center;
+    margin-bottom: var(--fs-spacing-4);
+    text-align: center;
+    font-size: var(--fs-text-size-1);
+  }
+
+  [data-fs-button] {
+    width: 100%;
+    [data-fs-button-wrapper] {
+      background-color: var(--fs-color-neutral-7);
+    }
+  }
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,8 @@
 import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+import CustomProductDetails from "./sections/CustomProductDetails/CustomProductDetails";
 
-export default { CustomIconsAlert };
+const sections = {
+  CustomIconsAlert: CustomIconsAlert,
+  ProductDetails: CustomProductDetails,
+};
+export default sections;

--- a/src/components/sections/CustomProductDetails/CustomProductDetails.tsx
+++ b/src/components/sections/CustomProductDetails/CustomProductDetails.tsx
@@ -1,0 +1,11 @@
+import { getOverriddenSection, ProductDetailsSection } from "@faststore/core";
+import { BuyButtonWithDetails } from "../../BuyButtonWithDetails/BuyButtonWithDetails";
+
+const CustomProductDetails = getOverriddenSection({
+  Section: ProductDetailsSection,
+  components: {
+    BuyButton: { Component: BuyButtonWithDetails },
+  },
+});
+
+export default CustomProductDetails;

--- a/src/fragments/ClientProduct.ts
+++ b/src/fragments/ClientProduct.ts
@@ -1,0 +1,20 @@
+// This file name should match the name of the query you want to extend.
+
+import { gql } from "@faststore/core/api";
+
+// Define the GraphQL fragment corresponding to the new fields you want to retrieve
+
+export const fragment = gql(`
+  fragment ClientProduct on Query {
+    product(locator: $locator) {
+      availableInstallments {
+        installmentPaymentSystemName
+        installmentValue
+        installmentInterest
+        installmentNumber
+      }
+    }
+  }
+`);
+
+// Refer to docs to see the list of FS Extendable queries: https://developers.vtex.com/docs/guides/faststore/api-extensions-extending-queries-using-fragments

--- a/src/fragments/ServerProduct.ts
+++ b/src/fragments/ServerProduct.ts
@@ -1,0 +1,20 @@
+// This file name should match the name of the query you want to extend.
+
+import { gql } from "@faststore/core/api";
+
+// Define the GraphQL fragment corresponding to the new fields you want to retrieve
+
+export const fragment = gql(`
+  fragment ServerProduct on Query {
+    product(locator: $locator) {
+      availableInstallments {
+        installmentPaymentSystemName
+        installmentValue
+        installmentInterest
+        installmentNumber
+      }
+    }
+  }
+`);
+
+// Refer to docs to see the list of FS Extendable queries: https://developers.vtex.com/docs/guides/faststore/api-extensions-extending-queries-using-fragments

--- a/src/graphql/vtex/resolvers/index.ts
+++ b/src/graphql/vtex/resolvers/index.ts
@@ -1,0 +1,7 @@
+import { default as StoreProductResolver } from "./product";
+
+const resolvers = {
+  ...StoreProductResolver,
+};
+
+export default resolvers;

--- a/src/graphql/vtex/resolvers/product.ts
+++ b/src/graphql/vtex/resolvers/product.ts
@@ -1,0 +1,23 @@
+import type { StoreProductRoot } from "@faststore/core/api";
+
+const productResolver = {
+  StoreProduct: {
+    // We will add a resolver to get the installments of a product, fetch only the data you need (https://developers.vtex.com/docs/guides/faststore/api-extensions-overview#best-practices-for-fetching-data)
+    availableInstallments: (root: StoreProductRoot) => {
+      const installments = root.sellers?.[0]?.commertialOffer?.Installments;
+
+      if (!installments.length) {
+        return [];
+      }
+
+      return installments.map((installment) => ({
+        installmentPaymentSystemName: installment.PaymentSystemName,
+        installmentValue: installment.Value,
+        installmentInterest: installment.InterestRate,
+        installmentNumber: installment.NumberOfInstallments,
+      }));
+    },
+  },
+};
+
+export default productResolver;

--- a/src/graphql/vtex/typeDefs/product.graphql
+++ b/src/graphql/vtex/typeDefs/product.graphql
@@ -1,0 +1,13 @@
+type Installments {
+  installmentPaymentSystemName: String!
+  installmentValue: Float!
+  installmentInterest: Float!
+  installmentNumber: Float!
+}
+
+extend type StoreProduct {
+  """
+  Retrieve available installments data extending StoreProduct
+  """
+  availableInstallments: [Installments!]!
+}

--- a/src/utils/priceFormatter.ts
+++ b/src/utils/priceFormatter.ts
@@ -1,0 +1,8 @@
+import FaststoreConfig from "../../faststore.config.js";
+
+export const priceFormatter = (value: number) => {
+  return value.toLocaleString(FaststoreConfig.session.locale, {
+    style: "currency",
+    currency: FaststoreConfig.session.currency.code,
+  });
+};


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds use cases scenarios using [API Extension](https://developers.vtex.com/docs/guides/faststore/api-extensions-overview).

FastStore API provides a [GraphQL schema for ecommerce](https://v1.faststore.dev/reference/api/queries) that covers a general use case, some stores may need to access other, more specific, information.

Note that adding additional API endpoints to your storefront can potentially impact site performance, as already covered in the guide [Best practices for fetching data](https://developers.vtex.com/docs/guides/faststore/api-extensions-overview#best-practices-for-fetching-data). If you need to retrieve more data, you can achieve this by extending the FastStore API schema and incorporating new data into the existing [queries](https://v1.faststore.dev/reference/api/queries).

## Examples

###  Use Case: Adds available installments information in PDP

This is an example of [Extending VTEX API Schemas](https://developers.vtex.com/docs/guides/faststore/api-extensions-extending-api-schema) and explore the following topics:

1. Creating type definitions (typeDefs): Added type definitions to `Installments`,  and `availableInstallments` extended from the existing FastStore API GraphQL type StoreProduct.
2. Creating resolvers: `src/graphql/vtex/resolvers`
3. [Extending queries using fragments](https://developers.vtex.com/docs/guides/faststore/api-extensions-extending-queries-using-fragments) 
4. [Consuming FastStore API extension with custom components](https://developers.vtex.com/docs/guides/faststore/api-extensions-consuming-api-extensions): using `usePDP` hook on `BuyButtonWithDetails` component

## How to test it?

- Go to any product page, if there is available installment option you should able to see above the `BuyButton` component.

ex: Go to http://localhost:3000/adidas-mens-performance-polo-green-night-99984111/p

<img width="1418" alt="image" src="https://github.com/vtex-sites/playground.store/assets/3356699/523ddb8e-5126-4fc9-945a-9bf28a84685c">
