### PR TITLE
Docs: Add new use case guide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ This example illustrates how to handle data from a Contact Us form and send it t
 - [📑 Documentation Reference - step by step guide](https://developers.vtex.com/docs/guides/faststore/api-extensions-use-cases-adding-a-contact-form-to-a-landing-page)
 - [➡️ Code Reference](https://github.com/vtex-sites/playground.store/tree/main/src/components/ContactForm)
 
+### [3. FastStore Analytics](https://developers.vtex.com/docs/guides/faststore/analytics-overview)
+
+The Analytics module supports sending and receiving different events, allowing you to implement custom event types and override default ones.
+
+#### Implementing custom newsletter analytics events
+
+This example explains how to track user subscriptions by implementing two custom analytics events for a custom newsletter section, `Submit newsletter` and `Submit newsletter success`.
+
+
+- [📑 Documentation Reference - step by step guide](https://developers.vtex.com/docs/guides/faststore/analytics-implementing-custom-newsletter-analytics-events)
+- [➡️ Code Reference](https://github.com/vtex-sites/playground.store/tree/main/src/components/sections/CustomNewsletter)
+
 ## 🏷️ Naming Conventions in this Project
 
 In this project, we'll be using the following naming conventions:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ The Analytics module supports sending and receiving different events, allowing y
 
 This example explains how to track user subscriptions by implementing two custom analytics events for a custom newsletter section, `Submit newsletter` and `Submit newsletter success`.
 
-
 - [📑 Documentation Reference - step by step guide](https://developers.vtex.com/docs/guides/faststore/analytics-implementing-custom-newsletter-analytics-events)
 - [➡️ Code Reference](https://github.com/vtex-sites/playground.store/tree/main/src/components/sections/CustomNewsletter)
 


### PR DESCRIPTION
## What's the purpose of this pull request?

Update README.md with the new use case guide reference, [Use case: Implementing custom newsletter analytics events](https://developers.vtex.com/docs/guides/faststore/analytics-implementing-custom-newsletter-analytics-events).

## How does it work?

<!--- Tell us the role of the new feature, or component, in its context. --->

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Faststore related PRs

<!--- Add a link to a faststore related PRs. --->

## References

<!--- Spread the knowledge: is there any content you used to create this PR that is worth sharing? --->

<!--- Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process --->
